### PR TITLE
Add ticket list pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,6 +2522,7 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "uuid",
 ]
 
 [[package]]

--- a/backend/src/handlers/tickets.rs
+++ b/backend/src/handlers/tickets.rs
@@ -3,14 +3,14 @@ use super::super::DbPool;
 use actix_web::{delete, error::InternalError, get, options, post, put, web, Error, HttpResponse};
 use diesel::prelude::*;
 use serde::Serialize;
-use shared::models::{response::Response, tickets::TicketEventType};
+use shared::models::{response::Response, tickets::{TicketEventType, TicketFilterPayload}};
 use uuid::Uuid;
 
 use crate::{
     models::{
         session::TypedSession,
         tickets::{
-            NewTicket, NewTicketEvent, NewTicketRevision, Ticket, TicketEvent, TicketFilterPayload,
+            NewTicket, NewTicketEvent, NewTicketRevision, Ticket, TicketEvent,
             TicketPayload, TicketRepresentation, TicketRevision, TicketUpdatePayload, UpdateTicket, TicketWrapper},
         users::User,
         SuccessResponse,

--- a/backend/src/handlers/tickets.rs
+++ b/backend/src/handlers/tickets.rs
@@ -2,7 +2,6 @@ use super::super::DbPool;
 
 use actix_web::{delete, error::InternalError, get, options, post, put, web, Error, HttpResponse};
 use diesel::prelude::*;
-use serde::Serialize;
 use shared::models::{response::Response, tickets::{TicketEventType, TicketFilterPayload}};
 use uuid::Uuid;
 
@@ -477,6 +476,15 @@ fn find(
     }
 
     let count = count_query.count().get_result::<i64>(conn)?;
+    
+    if count == 0 {
+        return Ok(TicketWrapper {
+            tickets: vec![],
+            page: page,
+            total_results: count,
+            total_pages: 0,
+        });
+    }
     let total_pages = (count as f64 / per_page as f64).ceil() as i64;
     
     //if page is greater than total pages, use the last page
@@ -495,8 +503,6 @@ fn find(
         .into_iter()
         .map(|(ticket, user)| TicketRepresentation::from((ticket, user)))
         .collect::<Vec<TicketRepresentation>>();
-
-    
 
     let wrapper = TicketWrapper {
         tickets: results,

--- a/backend/src/handlers/tickets.rs
+++ b/backend/src/handlers/tickets.rs
@@ -11,20 +11,15 @@ use crate::{
         session::TypedSession,
         tickets::{
             NewTicket, NewTicketEvent, NewTicketRevision, Ticket, TicketEvent, TicketFilterPayload,
-            TicketPayload, TicketRepresentation, TicketRevision, TicketUpdatePayload, UpdateTicket,
-        },
+            TicketPayload, TicketRepresentation, TicketRevision, TicketUpdatePayload, UpdateTicket, TicketWrapper},
         users::User,
         SuccessResponse,
     },
     utils::parse_uuid,
 };
 
-type DbError = Box<dyn std::error::Error + Send + Sync>;
 
-#[derive(Debug, Serialize)]
-struct TicketWrapper {
-    tickets: Vec<TicketRepresentation>,
-}
+type DbError = Box<dyn std::error::Error + Send + Sync>;
 
 //options
 #[options("/tickets")]
@@ -100,42 +95,35 @@ async fn index(
         find(&mut conn, Some(query.into_inner()))
     })
     .await?
-    .map(|x| {
-        x.into_iter()
-            .map(TicketRepresentation::from)
-            .collect::<Vec<TicketRepresentation>>()
-    })
     .map_err(actix_web::error::ErrorInternalServerError)?;
 
-    let ticket_list: TicketWrapper = TicketWrapper { tickets };
-
-    Ok(HttpResponse::Ok().json(ticket_list))
+    Ok(HttpResponse::Ok().json(tickets))
 }
 
-#[get("/tickets/assignee/{assignee}")]
-async fn by_assignee(
-    pool: web::Data<DbPool>,
-    assignee: web::Path<String>,
-) -> Result<HttpResponse, Error> {
-    //convert assignee to Uuid
-    let assignee_uuid = Uuid::parse_str(&assignee).unwrap();
+// #[get("/tickets/assignee/{assignee}")]
+// async fn by_assignee(
+//     pool: web::Data<DbPool>,
+//     assignee: web::Path<String>,
+// ) -> Result<HttpResponse, Error> {
+//     //convert assignee to Uuid
+//     let assignee_uuid = Uuid::parse_str(&assignee).unwrap();
 
-    let tickets = web::block(move || {
-        let mut conn = pool.get()?;
-        find_by_user_id(assignee_uuid, &mut conn)
-    })
-    .await?
-    .map(|x| {
-        x.into_iter()
-            .map(TicketRepresentation::from)
-            .collect::<Vec<TicketRepresentation>>()
-    })
-    .map_err(actix_web::error::ErrorInternalServerError)?;
+//     let tickets = web::block(move || {
+//         let mut conn = pool.get()?;
+//         find_by_user_id(assignee_uuid, &mut conn)
+//     })
+//     .await?
+//     .map(|x| {
+//         x.into_iter()
+//             .map(TicketRepresentation::from)
+//             .collect::<Vec<TicketRepresentation>>()
+//     })
+//     .map_err(actix_web::error::ErrorInternalServerError)?;
 
-    let ticket_list: TicketWrapper = TicketWrapper { tickets };
+//     let ticket_list: TicketWrapper = TicketWrapper { tickets };
 
-    Ok(HttpResponse::Ok().json(ticket_list))
-}
+//     Ok(HttpResponse::Ok().json(ticket_list))
+// }
 
 //get tickets by user_id
 #[get("/tickets?user_id={user_id}")]
@@ -444,18 +432,23 @@ async fn events(ticket_id: web::Path<i32>, pool: web::Data<DbPool>) -> Result<Ht
 fn find(
     conn: &mut PgConnection,
     filters: Option<TicketFilterPayload>,
-) -> Result<Vec<(Ticket, Option<User>)>, DbError> {
+) -> Result<TicketWrapper, DbError> {
     use crate::schema::tickets::dsl::*;
     use crate::schema::users::dsl::users;
 
     let mut query = tickets.left_join(users).into_boxed();
+    let mut count_query = tickets.into_boxed();
+    let mut page = 1;  
+    let mut per_page = 50;
 
     if let Some(filters) = filters {
         if let Some(tassignee) = filters.assignee {
             if tassignee == Uuid::nil() {
                 query = query.filter(assignee.is_null());
+                count_query = count_query.filter(assignee.is_null());
             } else {
                 query = query.filter(assignee.eq(tassignee));
+                count_query = count_query.filter(assignee.eq(tassignee));
             }
         }
 
@@ -463,15 +456,56 @@ fn find(
             if tstatus == "open" || tstatus == "Open" {
                 //anything but closed for now
                 query = query.filter(status.ne("Closed"));
+                count_query = count_query.filter(status.ne("Closed"));
             } else if tstatus == "closed" || tstatus == "Closed" {
                 query = query.filter(status.eq("Closed"));
+                count_query = count_query.filter(status.eq("Closed"));
+            }
+        }
+        
+        if let Some(p) = filters.page {
+            if p > 0 {
+                page = p;
+            }
+        }
+
+        if let Some(pp) = filters.per_page {
+            if pp > 0 {
+             per_page = pp;
             }
         }
     }
 
-    let items = query.load::<(Ticket, Option<User>)>(conn)?;
+    let count = count_query.count().get_result::<i64>(conn)?;
+    let total_pages = (count as f64 / per_page as f64).ceil() as i64;
+    
+    //if page is greater than total pages, use the last page
+    if page > total_pages {
+        page = total_pages;
+    }
 
-    Ok(items)
+    let offset = (page - 1) * per_page;
+    query = query.limit(per_page).offset(offset);
+
+    let items = query.load::<(Ticket, Option<User>)>(conn)?;
+    
+
+    //collect Vec<TicketRepresentation> from Vec<(Ticket, Option<User>)>
+    let results = items
+        .into_iter()
+        .map(|(ticket, user)| TicketRepresentation::from((ticket, user)))
+        .collect::<Vec<TicketRepresentation>>();
+
+    
+
+    let wrapper = TicketWrapper {
+        tickets: results,
+        page: page,
+        total_results: count,
+        total_pages: total_pages,
+    };
+
+    Ok(wrapper)
 }
 
 /// Find ticket by id and join with user
@@ -583,3 +617,5 @@ fn get_ticket_events(id: i32, conn: &mut PgConnection) -> Result<Vec<TicketEvent
 
     Ok(results)
 }
+
+

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -94,7 +94,7 @@ async fn main() -> std::io::Result<()> {
                     .service(handlers::users::whoami)
                     .service(handlers::tickets::options)
                     .service(handlers::tickets::index)
-                    .service(handlers::tickets::by_assignee)
+                    //.service(handlers::tickets::by_assignee)
                     .service(handlers::tickets::create)
                     .service(handlers::tickets::show)
                     .service(handlers::tickets::update)

--- a/backend/src/models/tickets.rs
+++ b/backend/src/models/tickets.rs
@@ -80,10 +80,20 @@ pub struct UpdateTicket {
     pub revision: Option<chrono::NaiveDateTime>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TicketFilterPayload {
     pub assignee: Option<Uuid>,
     pub status: Option<String>,
+    pub page: Option<i64>,
+    pub per_page: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TicketWrapper {
+    pub tickets: Vec<TicketRepresentation>,
+    pub page: i64,
+    pub total_pages: i64,
+    pub total_results: i64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Queryable, Clone)]

--- a/backend/src/models/tickets.rs
+++ b/backend/src/models/tickets.rs
@@ -80,14 +80,6 @@ pub struct UpdateTicket {
     pub revision: Option<chrono::NaiveDateTime>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct TicketFilterPayload {
-    pub assignee: Option<Uuid>,
-    pub status: Option<String>,
-    pub page: Option<i64>,
-    pub per_page: Option<i64>,
-}
-
 #[derive(Debug, Serialize)]
 pub struct TicketWrapper {
     pub tickets: Vec<TicketRepresentation>,

--- a/frontend/src/components/ticket_list.rs
+++ b/frontend/src/components/ticket_list.rs
@@ -63,7 +63,7 @@ pub fn ticket_list() -> Html {
         assignee: Some(user_ctx.user_id.clone()),
         status: Some(StatusFilter::Open.to_string()),
         page: Some(1),
-        per_page: Some(1),
+        per_page: Some(50),
     });
     //let ticket_list = use_state(|| TicketListInfo::default());
 
@@ -233,14 +233,17 @@ let onclick_filter_per_page = {
             .unwrap()
             .unchecked_into();
         let value = input.value();
-        let mut new_filter = TicketFilterPayload {
-            assignee: filter.assignee.clone(),
-            status: filter.status.clone(),
-            page: filter.page.clone(),
-            per_page: filter.per_page.clone(),
-        };
-        new_filter.per_page = Some(value.parse::<i64>().unwrap());
-        filter.set(new_filter);
+        //must be greater than 0
+        if value.parse::<i64>().unwrap() > 0 {
+            let mut new_filter = TicketFilterPayload {
+                assignee: filter.assignee.clone(),
+                status: filter.status.clone(),
+                page: filter.page.clone(),
+                per_page: filter.per_page.clone(),
+            };
+            new_filter.per_page = Some(value.parse::<i64>().unwrap());
+            filter.set(new_filter);
+        }
     })
 };
 
@@ -346,41 +349,45 @@ let onclick_filter_per_page = {
                     }
                     } else {
                         html! {
-                            <tr>
-                                <td colspan="7">{language.get("No tickets")}</td>
-                            </tr>
                         }
                     }
                     }
 
                 </table>
             </div>
-            <div class="pagination">
-                <button class="btn" onclick={onclick_prev_page} disabled={ticket_list.page == 1}>
-                    {language.get("Prev")}
-                </button>
-                <span style="margin: 0px 8px;">{format!("{} / {}", ticket_list.page, ticket_list.total_pages)}</span>
-                <button class="btn" onclick={onclick_next_page} disabled={ticket_list.page == ticket_list.total_pages}>
-                    {language.get("Next")}
-                </button>
-            </div>
-            //"Results: {} - {} of {}"
-            <div>
-                <span>{format!("{} - {} of {}", ticket_list.page * filter.per_page.unwrap() - filter.per_page.unwrap() + 1, 
-                if ticket_list.total_results > ticket_list.page * filter.per_page.unwrap() {
-                    ticket_list.page * filter.per_page.unwrap()
-                } else {
-                    ticket_list.total_results
-                }, 
-                ticket_list.total_results)}</span>
-            </div>
-            //allow user to select results per page (input field, show the current amount by default
+            { if ticket_list.total_results == 0 {
+                html!{ language.get("No results") }
+                }
+                else { 
+                    html! {
+                        <>
+                            <div class="pagination">
+                                <button class="btn" onclick={onclick_prev_page} disabled={ticket_list.page == 1}>
+                                    {"<"}
+                                </button>
+                                <span style="margin: 0px 8px;">{format!("{} / {}", ticket_list.page, ticket_list.total_pages)}</span>
+                                <button class="btn" onclick={onclick_next_page} disabled={ticket_list.page == ticket_list.total_pages}>
+                                    {">"}
+                                </button>
+                            </div>
+                            <div>   
+                                <span>{format!("{} - {} of {}", ticket_list.page * filter.per_page.unwrap() - filter.per_page.unwrap() + 1, 
+                                if ticket_list.total_results > ticket_list.page * filter.per_page.unwrap() {
+                                    ticket_list.page * filter.per_page.unwrap()
+                                } else {
+                                    ticket_list.total_results
+                                }, 
+                                ticket_list.total_results)}</span>
+                            </div>
+                        </>
+                    }
+                }
+            }
             <div>
                 <span>{language.get("Results per page: ")}</span>
-                //use button to submit
-                <input type="number" id="perpage" value={filter.per_page.unwrap().to_string()} />
+                <input style="width: 80px;" type="number" id="perpage" value={filter.per_page.unwrap().to_string()} />
                 <button class="btn" onclick={onclick_filter_per_page}>
-                    {language.get("Submit")}
+                    {"✔️"}
                 </button>
             </div>
         </div>

--- a/frontend/src/styles/global.rs
+++ b/frontend/src/styles/global.rs
@@ -74,7 +74,7 @@ pub fn global_style() -> Html {
                 display: inline-flex;
                 border: none;
                 justify-content: center;
-                min-width: 60px;
+                min-width: 32px;
                 vertical-align: middle;
             }
             .btn:hover {

--- a/frontend/src/types/tickets.rs
+++ b/frontend/src/types/tickets.rs
@@ -32,10 +32,12 @@ pub struct TicketInfoWrapper {
     pub ticket: TicketInfo,
 }
 
-//Arbitrarily decided to user a wrapper for list of tickets
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
 pub struct TicketListInfo {
     pub tickets: Vec<TicketInfo>,
+    pub page: i64,
+    pub total_pages: i64,
+    pub total_results: i64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+uuid = { version = "1.2.2", features = ["serde", "v4"] }

--- a/shared/src/models/tickets.rs
+++ b/shared/src/models/tickets.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum TicketEventType {
@@ -22,4 +23,13 @@ impl ToString for TicketEventType {
             TicketEventType::TitleUpdated => "title_updated".to_string(),
         }
     }
+}
+
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct TicketFilterPayload {
+    pub assignee: Option<Uuid>,
+    pub status: Option<String>,
+    pub page: Option<i64>,
+    pub per_page: Option<i64>,
 }


### PR DESCRIPTION
Introduce pagination for the ticket list.  Allow for the page and results per page to be specified, return page, total results, and number of pages.  Allow user to select results per page and page (if more than 1) on ticket list.  Setting these in user preferences would be nice too.