### PR TITLE
Display local user time (#2)

### DIFF
--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -5,6 +5,7 @@ use yew_router::prelude::*;
 use crate::components::nav::Navigation;
 use crate::contexts::language::LanguageProvider;
 use crate::contexts::theme::ThemeProvider;
+use crate::contexts::time::TimeContextProvider;
 use crate::contexts::user::UserContextProvider;
 use crate::routes::{switch, AppRoute};
 use crate::styles::global::GlobalStyle;
@@ -14,14 +15,16 @@ pub fn app() -> Html {
     html! {
         <ThemeProvider>
         <GlobalStyle />
-            <UserContextProvider>
-                <BrowserRouter>
-                    <LanguageProvider>
-                        <Navigation />
-                        <Switch<AppRoute> render={switch} />
-                    </LanguageProvider>
-              </BrowserRouter>
-          </UserContextProvider>
+          <TimeContextProvider>
+                <UserContextProvider>
+                    <BrowserRouter>
+                        <LanguageProvider>
+                            <Navigation />
+                            <Switch<AppRoute> render={switch} />
+                        </LanguageProvider>
+                    </BrowserRouter>
+                </UserContextProvider>
+            </TimeContextProvider>
         </ThemeProvider>
     }
 }

--- a/frontend/src/components/ticket_list.rs
+++ b/frontend/src/components/ticket_list.rs
@@ -473,6 +473,7 @@ let onclick_filter_per_page = {
                             </td>
                             <td style={
                                 if let Some(due_date) = &ticket.due_date {
+                                    //Convert current time to utc to compare with due_date which is stored as utc
                                     let current_time = Local::now().naive_utc();
                                     if due_date < &current_time {
                                         "background-color: rgb(255 31 31 / 40%);"
@@ -485,7 +486,7 @@ let onclick_filter_per_page = {
                             }>
                                 <span class="date">
                                     { if let Some(due_date) = &ticket.due_date {
-                                        due_date.format("%Y/%m/%d %H:%M").to_string()
+                                        time_ctx.convert_to_local(&due_date).format("%Y/%m/%d %H:%M").to_string()
                                     } else {
                                         "".to_string()
                                     }}

--- a/frontend/src/components/ticket_list.rs
+++ b/frontend/src/components/ticket_list.rs
@@ -20,7 +20,6 @@ use crate::hooks::use_user_context;
 use crate::routes::AppRoute;
 use crate::services::{tickets::*, users::get_users};
 use crate::types::TicketListInfo;
-use crate::utils::to_local_time;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Filter {
@@ -75,8 +74,6 @@ pub fn ticket_list() -> Html {
     });
     let loading = use_state(|| false);
     let time_ctx = use_time();
-    let tz_offset = *time_ctx.inner;
-    log::info!("Offset: {}", tz_offset);
 
     let users = use_future(|| async { get_users().await.unwrap_or_default() });
 
@@ -466,12 +463,12 @@ let onclick_filter_per_page = {
                             <td>
                                 <span class="date">
                                     //Convert from native
-                                    { to_local_time(&ticket.created_at, 540).format("%Y/%m/%d %H:%M")}
+                                    { time_ctx.convert_to_local(&ticket.created_at).format("%Y/%m/%d %H:%M") }
                                 </span>
                             </td>
                             <td>
                                 <span class="date">
-                                    { &ticket.updated_at.format("%Y/%m/%d %H:%M") }
+                                    { time_ctx.convert_to_local(&ticket.updated_at).format("%Y/%m/%d %H:%M") }
                                 </span>
                             </td>
                             <td style={

--- a/frontend/src/components/ticket_list.rs
+++ b/frontend/src/components/ticket_list.rs
@@ -14,11 +14,13 @@ use yew_router::prelude::Link;
 
 use crate::components::loading::Loading;
 use crate::contexts::theme::use_theme;
+use crate::contexts::time::use_time;
 use crate::hooks::use_language_context;
 use crate::hooks::use_user_context;
 use crate::routes::AppRoute;
 use crate::services::{tickets::*, users::get_users};
 use crate::types::TicketListInfo;
+use crate::utils::to_local_time;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Filter {
@@ -72,6 +74,9 @@ pub fn ticket_list() -> Html {
         search: None,
     });
     let loading = use_state(|| false);
+    let time_ctx = use_time();
+    let tz_offset = *time_ctx.inner;
+    log::info!("Offset: {}", tz_offset);
 
     let users = use_future(|| async { get_users().await.unwrap_or_default() });
 
@@ -460,7 +465,8 @@ let onclick_filter_per_page = {
                             </td>
                             <td>
                                 <span class="date">
-                                    { &ticket.created_at.format("%Y/%m/%d %H:%M") }
+                                    //Convert from native
+                                    { to_local_time(&ticket.created_at, 540).format("%Y/%m/%d %H:%M")}
                                 </span>
                             </td>
                             <td>

--- a/frontend/src/contexts/mod.rs
+++ b/frontend/src/contexts/mod.rs
@@ -1,3 +1,4 @@
 pub mod language;
 pub mod theme;
 pub mod user;
+pub mod time;

--- a/frontend/src/contexts/time.rs
+++ b/frontend/src/contexts/time.rs
@@ -1,0 +1,46 @@
+use chrono::Local;
+use yew::prelude::*;
+
+#[derive(Properties, Clone, PartialEq)]
+pub struct Props {
+    pub children: Children,
+}
+
+#[function_component(TimeContextProvider)]
+pub fn time_context_provider(props: &Props) -> Html {
+    let time_ctx = use_state(|| i32::default());
+
+    let offset = Local::now().offset().local_minus_utc() / 60;
+
+    {
+        let time_ctx = time_ctx.clone();
+        use_effect_with_deps(
+            move |_| {
+                let time_ctx = time_ctx.clone();
+                wasm_bindgen_futures::spawn_local(async move {
+                    time_ctx.set(offset);
+                });
+                || {}
+            },
+            (),
+        );
+    }
+
+    html! {
+        <ContextProvider<UseStateHandle<i32>> context={time_ctx}>
+            { for props.children.clone() }
+        </ContextProvider<UseStateHandle<i32>>>
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TimeContext {
+    pub inner: UseStateHandle<i32>,
+}
+
+#[hook]
+pub(crate) fn use_time() -> TimeContext {
+    let inner = use_context::<UseStateHandle<i32>>().expect("No context found");
+
+    TimeContext { inner }
+}

--- a/frontend/src/contexts/time.rs
+++ b/frontend/src/contexts/time.rs
@@ -1,4 +1,4 @@
-use chrono::Local;
+use chrono::{Local, TimeZone};
 use yew::prelude::*;
 
 #[derive(Properties, Clone, PartialEq)]
@@ -43,4 +43,16 @@ pub(crate) fn use_time() -> TimeContext {
     let inner = use_context::<UseStateHandle<i32>>().expect("No context found");
 
     TimeContext { inner }
+}
+
+impl TimeContext {
+    pub fn offset(&self) -> i32 {
+        *self.inner
+    }
+    pub fn convert_to_local(&self, time: &chrono::NaiveDateTime) -> chrono::NaiveDateTime {
+        let offset = self.offset();
+        let local: chrono::FixedOffset = chrono::FixedOffset::east_opt(offset * 60).unwrap();
+
+        local.from_utc_datetime(&time).naive_local()
+    }
 }

--- a/frontend/src/contexts/time.rs
+++ b/frontend/src/contexts/time.rs
@@ -10,7 +10,7 @@ pub struct Props {
 pub fn time_context_provider(props: &Props) -> Html {
     let time_ctx = use_state(|| i32::default());
 
-    let offset = Local::now().offset().local_minus_utc() / 60;
+    let offset = Local::now().offset().local_minus_utc();
 
     {
         let time_ctx = time_ctx.clone();
@@ -51,13 +51,13 @@ impl TimeContext {
     }
     pub fn convert_to_local(&self, time: &chrono::NaiveDateTime) -> chrono::NaiveDateTime {
         let offset = self.offset();
-        let local: chrono::FixedOffset = chrono::FixedOffset::east_opt(offset * 60).unwrap();
+        let local: chrono::FixedOffset = chrono::FixedOffset::east_opt(offset).unwrap();
 
         local.from_utc_datetime(&time).naive_local()
     }
     pub fn convert_to_utc(&self, time: &chrono::NaiveDateTime) -> chrono::NaiveDateTime {
         let offset = self.offset();
-        let local: chrono::FixedOffset = chrono::FixedOffset::east_opt(offset * 60).unwrap();
+        let local: chrono::FixedOffset = chrono::FixedOffset::east_opt(offset).unwrap();
 
         local.from_local_datetime(&time).unwrap().naive_utc()
     }

--- a/frontend/src/contexts/time.rs
+++ b/frontend/src/contexts/time.rs
@@ -55,4 +55,10 @@ impl TimeContext {
 
         local.from_utc_datetime(&time).naive_local()
     }
+    pub fn convert_to_utc(&self, time: &chrono::NaiveDateTime) -> chrono::NaiveDateTime {
+        let offset = self.offset();
+        let local: chrono::FixedOffset = chrono::FixedOffset::east_opt(offset * 60).unwrap();
+
+        local.from_local_datetime(&time).unwrap().naive_utc()
+    }
 }

--- a/frontend/src/routes/ticket/event.rs
+++ b/frontend/src/routes/ticket/event.rs
@@ -3,6 +3,7 @@ use stylist::yew::styled_component;
 use yew::prelude::*;
 
 use crate::components::time_format::TimeFormat;
+use crate::contexts::time::use_time;
 use crate::hooks::use_language_context;
 use crate::types::events::TicketEvent;
 
@@ -16,6 +17,7 @@ pub struct Props {
 pub fn event(props: &Props) -> Html {
     let event = &props.event;
     let language = use_language_context();
+    let time_ctx = use_time();
 
     let actor_display = get_actor_display_name(props.userlist.clone(), event);
 
@@ -25,30 +27,66 @@ pub fn event(props: &Props) -> Html {
             if event.event_data == "" {
                 format!("{} {}", actor_display, language.get("unassigned ticket"))
             } else {
-                let target_display = get_target_display_name(props.userlist.clone(), event.event_data.clone());
-                format!("{} {} {}", actor_display, language.get("assigned ticket to"), target_display)
+                let target_display =
+                    get_target_display_name(props.userlist.clone(), event.event_data.clone());
+                format!(
+                    "{} {} {}",
+                    actor_display,
+                    language.get("assigned ticket to"),
+                    target_display
+                )
             }
         }
         "status_updated" => {
-            format!("{} {} {}", actor_display, language.get("updated ticket status to"), event.event_data)
+            format!(
+                "{} {} {}",
+                actor_display,
+                language.get("updated ticket status to"),
+                event.event_data
+            )
         }
         "priority_updated" => {
-            format!("{} {} {}", actor_display, language.get("updated ticket priority to"), event.event_data)
+            format!(
+                "{} {} {}",
+                actor_display,
+                language.get("updated ticket priority to"),
+                event.event_data
+            )
         }
         "title_updated" => {
-            format!("{} {} {}", actor_display, language.get("updated ticket title to"), event.event_data)
+            format!(
+                "{} {} {}",
+                actor_display,
+                language.get("updated ticket title to"),
+                event.event_data
+            )
         }
         "due_date_updated" => {
             if event.event_data == "" {
                 format!("{} {}", actor_display, language.get("removed due date"))
             } else {
-                format!("{} {} {}", actor_display, language.get("updated due date to"), event.event_data)
+                format!(
+                    "{} {} {}",
+                    actor_display,
+                    language.get("updated due date to"),
+                    //Parse due date from str to NaiveDateTime, convert to local time, then format
+                    time_ctx
+                        .convert_to_local(
+                            &chrono::NaiveDateTime::parse_from_str(
+                                &event.event_data,
+                                "%Y-%m-%d %H:%M:%S"
+                            )
+                            .unwrap()
+                        )
+                        .format("%Y-%m-%d %H:%M")
+                        .to_string()
+                )
             }
         }
         _ => "Unknown event".to_string(),
     };
 
-    html!{
+    html! {
         <div class="event-card">
             <TimeFormat time={event.created_at.clone()}/>
             {format!(": {}", event_string)}
@@ -59,15 +97,11 @@ pub fn event(props: &Props) -> Html {
 fn get_actor_display_name(userlist: Vec<UserDisplay>, event: &TicketEvent) -> String {
     //match the user_id of event to a user_id in userlist
     let actor_display = match event.user_id {
-        Some(uuid) => match userlist
-            .iter()
-            .find(|user| user.user_id == uuid) {
-                Some(user) => user.display_name.clone(),
-                None => "unknown".to_string(),
-            },
-        None => {
-            "unknown".to_string()
-        }
+        Some(uuid) => match userlist.iter().find(|user| user.user_id == uuid) {
+            Some(user) => user.display_name.clone(),
+            None => "unknown".to_string(),
+        },
+        None => "unknown".to_string(),
     };
 
     actor_display
@@ -75,17 +109,12 @@ fn get_actor_display_name(userlist: Vec<UserDisplay>, event: &TicketEvent) -> St
 
 //function to try to get display name by UUID
 fn get_target_display_name(userlist: Vec<UserDisplay>, event_data: String) -> String {
-
     //first try to parse the Uuid, if it fails, return unknown, if it is "unassigned", return "unassigned"
     let target_display = match event_data.parse::<uuid::Uuid>() {
-        Ok(uuid) => {
-            match userlist
-                .iter()
-                .find(|user| user.user_id == uuid) {
-                    Some(user) => user.display_name.clone(),
-                    None => "unknown".to_string(),
-                }
-        }
+        Ok(uuid) => match userlist.iter().find(|user| user.user_id == uuid) {
+            Some(user) => user.display_name.clone(),
+            None => "unknown".to_string(),
+        },
         Err(_) => {
             if event_data == "unassigned" {
                 "unassigned".to_string()

--- a/frontend/src/routes/ticket/mod.rs
+++ b/frontend/src/routes/ticket/mod.rs
@@ -10,6 +10,7 @@ use stylist::yew::styled_component;
 use yew::prelude::*;
 use yew::suspense::use_future;
 
+use crate::contexts::time::use_time;
 use crate::services::tickets::*;
 use crate::services::users::get_display_names;
 use crate::types::TicketInfo;
@@ -26,6 +27,8 @@ pub struct Props {
 #[styled_component(Ticket)]
 pub fn ticket(props: &Props) -> Html {
     let ticket = use_state(|| TicketInfo::default());
+    let time_ctx = use_time();
+    
     {
         let ticket = ticket.clone();
         let props = props.clone();
@@ -138,16 +141,16 @@ pub fn ticket(props: &Props) -> Html {
                     </div>
                     <div class="created-date">
                         { "Created " }
-                        { ticket.created_at.format("%Y-%m-%d %H:%M").to_string() }
+                        { time_ctx.convert_to_local(&ticket.created_at).format("%Y-%m-%d %H:%M") }
                     </div>
                     <div class="updated-date">
                         { "Updated " }
-                        { ticket.updated_at.format("%Y-%m-%d %H:%M").to_string() }
+                        { time_ctx.convert_to_local(&ticket.updated_at).format("%Y-%m-%d %H:%M") }
                     </div>
                     <div class="due-date">
                         { "Due date: " }
-                        { if ticket.due_date.is_some() {
-                            html!  { ticket.due_date.as_ref().unwrap().format("%Y-%m-%d %H:%M").to_string() }
+                        { if let Some(due_date) = ticket.due_date {
+                            html! { time_ctx.convert_to_local(&due_date).format("%Y-%m-%d %H:%M") }
                         } else {
                             html! { "None" }
                         } }

--- a/frontend/src/routes/ticket_editor.rs
+++ b/frontend/src/routes/ticket_editor.rs
@@ -332,7 +332,6 @@ pub fn ticket_editor(props: &Props) -> Html {
                             <input type="datetime-local" style="width: fit-content;" value={
                                 if let Some(due_date) = update_info.due_date.clone() {
                                     Local.from_local_datetime(&due_date.clone()).unwrap().format("%Y-%m-%dT%H:%M").to_string()
-                                    //time_ctx.convert_to_local(&due_date).format("%Y-%m-%dT%H:%M").to_string()
                                 } else {
                                     "".to_string()
                                 }

--- a/frontend/src/routes/ticket_editor.rs
+++ b/frontend/src/routes/ticket_editor.rs
@@ -12,6 +12,7 @@ use yew::prelude::*;
 use yew::suspense::use_future;
 use yew_router::prelude::*;
 
+use crate::contexts::time::use_time;
 use crate::hooks::{use_language_context, use_user_context};
 use crate::routes::AppRoute;
 use crate::services::tickets::*;
@@ -31,6 +32,7 @@ pub fn ticket_editor(props: &Props) -> Html {
     let user_ctx = use_user_context();
     let loading = use_state(|| true);
     let language = use_language_context();
+    let time_ctx = use_time();
     let update_info = use_state(
         || TicketCreateInfo {
             assignee: Some(user_ctx.user_id),
@@ -55,6 +57,7 @@ pub fn ticket_editor(props: &Props) -> Html {
         let props = props.clone();
         let update_info = update_info.clone();
         let retrieved_ticket = retrieved_ticket.clone();
+        let time_ctx = time_ctx.clone();
         use_effect_with_deps(
             move |_| {
                 wasm_bindgen_futures::spawn_local(async move {
@@ -74,7 +77,12 @@ pub fn ticket_editor(props: &Props) -> Html {
                                     contact: ticket.contact,
                                     priority: ticket.priority,
                                     status: ticket.status,
-                                    due_date: ticket.due_date,
+                                    due_date:
+                                        if let Some(due_date) = ticket.due_date {
+                                            Some(time_ctx.convert_to_local(&due_date))
+                                        } else {
+                                            None
+                                        },
                                 });
                             }
                             Err(e) => {
@@ -98,6 +106,7 @@ pub fn ticket_editor(props: &Props) -> Html {
         let submitted = submitted.clone();
         let props = props.clone();
         let retrieved_ticket = retrieved_ticket.clone();
+        let time_ctx = time_ctx.clone();
         use_effect_with_deps(
             move |submitted| {
                 if **submitted {
@@ -120,7 +129,12 @@ pub fn ticket_editor(props: &Props) -> Html {
                                 contact: Some(update_info.contact.clone()),
                                 priority: Some(update_info.priority.clone()),
                                 status: Some(update_info.status.clone()),
-                                due_date: Some(update_info.due_date.clone()),
+                                due_date: Some( if let Some(due_date) = update_info.due_date {
+                                    Some(time_ctx.convert_to_utc(&due_date))
+                                } else {
+                                    None
+                                }
+                                ),
                                 version: Some(retrieved_ticket.revision.clone()),
                             };
                             update(ticket_id, &request).await
@@ -216,11 +230,10 @@ pub fn ticket_editor(props: &Props) -> Html {
         Callback::from(move |e: InputEvent| {
             let input: HtmlInputElement = e.target_unchecked_into();
             let mut info = (*update_info).clone();
-            //datetime-local to naive datetime
             if input.value().is_empty() {
                 info.due_date = None;
             } else {
-                info.due_date = Some(NaiveDateTime::parse_from_str(input.value().as_str(), "%Y-%m-%dT%H:%M").unwrap());
+                info.due_date = Some(Local.datetime_from_str(&input.value(), "%Y-%m-%dT%H:%M").unwrap().naive_local());
             }
             update_info.set(info);    
         })
@@ -319,6 +332,7 @@ pub fn ticket_editor(props: &Props) -> Html {
                             <input type="datetime-local" style="width: fit-content;" value={
                                 if let Some(due_date) = update_info.due_date.clone() {
                                     Local.from_local_datetime(&due_date.clone()).unwrap().format("%Y-%m-%dT%H:%M").to_string()
+                                    //time_ctx.convert_to_local(&due_date).format("%Y-%m-%dT%H:%M").to_string()
                                 } else {
                                     "".to_string()
                                 }

--- a/frontend/src/utils/mod.rs
+++ b/frontend/src/utils/mod.rs
@@ -1,3 +1,5 @@
 mod markdown;
+mod time;
 
 pub use markdown::markdown_to_html;
+pub use time::to_local_time;

--- a/frontend/src/utils/mod.rs
+++ b/frontend/src/utils/mod.rs
@@ -1,5 +1,3 @@
 mod markdown;
-mod time;
 
 pub use markdown::markdown_to_html;
-pub use time::to_local_time;

--- a/frontend/src/utils/time.rs
+++ b/frontend/src/utils/time.rs
@@ -1,7 +1,0 @@
-use chrono::{NaiveDateTime, FixedOffset, TimeZone};
-
-pub fn to_local_time(time: &NaiveDateTime, offset: i32) -> NaiveDateTime {
-    let local: FixedOffset = FixedOffset::east_opt(offset * 60).unwrap();
-
-    local.from_utc_datetime(&time).naive_local()
-}

--- a/frontend/src/utils/time.rs
+++ b/frontend/src/utils/time.rs
@@ -1,0 +1,7 @@
+use chrono::{NaiveDateTime, FixedOffset, TimeZone};
+
+pub fn to_local_time(time: &NaiveDateTime, offset: i32) -> NaiveDateTime {
+    let local: FixedOffset = FixedOffset::east_opt(offset * 60).unwrap();
+
+    local.from_utc_datetime(&time).naive_local()
+}


### PR DESCRIPTION
All time is recorded as UTC, and the client currently displays the UTC time as is.  This PR will create a context that gets the client's time (offset) in the frontend, then converts the time received from the server and uses that offset to convert and display the time in the user's timezone.

- [x] Create time context that gets the user's offset
- [x] Create a function that uses the offset to 
- [ ] Apply function to all timestamp displays
- [x] Handle client-side date selections (i.e. due date)