### PR TITLE
Add nested router for settings

### DIFF
--- a/frontend/src/components/nav.rs
+++ b/frontend/src/components/nav.rs
@@ -107,7 +107,7 @@ pub fn navigation() -> Html {
                             <img src="./img/Enso.svg" alt="Enso Logo" class="logo" />
                         </Link<AppRoute>>
                         <div class="nav-user">
-                            <Link<AppRoute> to={AppRoute::Settings}>
+                            <Link<AppRoute> to={AppRoute::SettingsRoot}>
                                 { user_ctx.display_name.clone() }
                             </Link<AppRoute>>
                         </div>
@@ -138,6 +138,15 @@ pub fn navigation() -> Html {
                                 }
                                 }>
                                 { language.get("Users") }
+                            </Link<AppRoute>>
+                            <Link<AppRoute> to={AppRoute::SettingsRoot} classes={
+                                if route == AppRoute::Settings || route == AppRoute::SettingsRoot {
+                                "selected nav-link"
+                                } else {
+                                "nav-link"
+                                }
+                                }>
+                                { language.get("Settings") }
                             </Link<AppRoute>>
                             //{ "Contacts" }
                             //{ "Assets" }

--- a/frontend/src/routes/mod.rs
+++ b/frontend/src/routes/mod.rs
@@ -83,9 +83,9 @@ pub fn switch(route: AppRoute) -> Html {
 
 pub fn switch_settings(route: SettingsRoute) -> Html {
     match route {
-        SettingsRoute::Profile => html! {<Settings user_id={None}/>},
-        SettingsRoute::Account { user_id }=> html! {<Settings user_id={Some(user_id.clone())}/>},
-        SettingsRoute::Tickets => html! {<Settings user_id={None}/>},
+        SettingsRoute::Profile => html! {<Settings />},
+        SettingsRoute::Account { user_id } => html! {<Settings />},
+        SettingsRoute::Tickets => html! {<Settings />},
         SettingsRoute::NotFound => html! {<Redirect<AppRoute> to={AppRoute::NotFound}/>}
     }
 }

--- a/frontend/src/routes/mod.rs
+++ b/frontend/src/routes/mod.rs
@@ -84,7 +84,7 @@ pub fn switch(route: AppRoute) -> Html {
 pub fn switch_settings(route: SettingsRoute) -> Html {
     match route {
         SettingsRoute::Profile => html! {<Settings />},
-        SettingsRoute::Account { user_id } => html! {<Settings />},
+        SettingsRoute::Account { user_id: _ } => html! {<Settings />},
         SettingsRoute::Tickets => html! {<Settings />},
         SettingsRoute::NotFound => html! {<Redirect<AppRoute> to={AppRoute::NotFound}/>}
     }

--- a/frontend/src/routes/mod.rs
+++ b/frontend/src/routes/mod.rs
@@ -36,15 +36,28 @@ pub enum AppRoute {
     #[at("/wiki/:document_id")]
     WikiDoc { document_id: uuid::Uuid },
     #[at("/settings")]
+    SettingsRoot,
+    #[at("/settings/*")]
     Settings,
-    #[at("/settings/:user_id")]
-    SettingsOther { user_id: uuid::Uuid },
     #[at("/users")]
     Users,
     #[at("/")]
     Home,
     #[not_found]
     #[at("/404")]
+    NotFound,
+}
+
+#[derive(Clone, Routable, PartialEq)]
+pub enum SettingsRoute {
+    #[at("/settings")]
+    Profile,
+    #[at("/settings/account/:user_id")]
+    Account { user_id: uuid::Uuid },
+    #[at("/settings/tickets")]
+    Tickets,
+    #[not_found]
+    #[at("/settings/404")]
     NotFound,
 }
 
@@ -58,11 +71,21 @@ pub fn switch(route: AppRoute) -> Html {
         }
         AppRoute::EditorCreate => html! {<TicketEditor />},
         AppRoute::Ticket { ticket_id } => html! {<Ticket ticket_id={ticket_id.clone()} />},
-        AppRoute::Settings => html! {<Settings />},
-        AppRoute::SettingsOther { user_id } => html! {<Settings user_id={user_id.clone()}/>},
+        // AppRoute::Settings => html! {<Settings />},
+        // AppRoute::SettingsOther { user_id } => html! {<Settings user_id={user_id.clone()}/>},
+        AppRoute::SettingsRoot | AppRoute::Settings => html! { <Switch<SettingsRoute> render={switch_settings} /> },
         AppRoute::Users => html! {<Users />},
         AppRoute::NotFound => html! { "Page not found" },
         AppRoute::WikiHome => html! {<Wiki document_id={None}/>},
         AppRoute::WikiDoc { document_id } => html!(<Wiki document_id={Some(document_id.clone())}/>),
+    }
+}
+
+pub fn switch_settings(route: SettingsRoute) -> Html {
+    match route {
+        SettingsRoute::Profile => html! {<Settings user_id={None}/>},
+        SettingsRoute::Account { user_id }=> html! {<Settings user_id={Some(user_id.clone())}/>},
+        SettingsRoute::Tickets => html! {<Settings user_id={None}/>},
+        SettingsRoute::NotFound => html! {<Redirect<AppRoute> to={AppRoute::NotFound}/>}
     }
 }

--- a/frontend/src/routes/settings/account.rs
+++ b/frontend/src/routes/settings/account.rs
@@ -17,8 +17,8 @@ pub struct Props {
 }
 
 /// Update user settings
-#[function_component(Settings)]
-pub fn settings(props: &Props) -> Html {
+#[function_component(Account)]
+pub fn account(props: &Props) -> Html {
     let user_ctx = use_user_context();
     let language = use_language_context();
     let submitted = use_state(|| false);

--- a/frontend/src/routes/settings/account.rs
+++ b/frontend/src/routes/settings/account.rs
@@ -17,7 +17,7 @@ pub struct Props {
 }
 
 /// Update user settings
-#[function_component(Account)]
+#[function_component(AccountSettings)]
 pub fn account(props: &Props) -> Html {
     let user_ctx = use_user_context();
     let language = use_language_context();

--- a/frontend/src/routes/settings/mod.rs
+++ b/frontend/src/routes/settings/mod.rs
@@ -1,9 +1,11 @@
 mod account;
 mod nav;
 
+use stylist::style;
 use yew::prelude::*;
 use yew_router::prelude::use_route;
 
+use crate::contexts::theme;
 use crate::routes::SettingsRoute;
 use crate::routes::settings::account::AccountSettings;
 use crate::routes::settings::nav::SettingsNav;
@@ -13,45 +15,97 @@ use super::AppRoute;
 /// Update user settings
 #[function_component(Settings)]
 pub fn settings() -> Html {
+    let theme = theme::use_theme();
 
     let route = match use_route::<SettingsRoute>() {
         Some(route) => route,
         None => SettingsRoute::Profile,
     };
+
+    let style = style! {
+        r#"
+        .settings {
+            display: flex;
+            flex-direction: row;
+            height: 100%;
+            width: 100%;
+        }
+        .settings-nav {
+            flex-grow: 1;
+            max-width: 200px;
+            overflow: auto;
+            height: 100%;
+            border-right: 1px solid #777;
+            width: 30%;
+        }
+        .settings-nav ul {
+            list-style: none;
+            padding: 2px 0 0px 20px;
+        }
+        .settings-nav li {
+            list-style: none;
+            padding: 2px 0 2px 0px;
+            font-size: 1.2em;
+        }     
+        .nav-link {
+            padding: 2px 8px;
+            text-decoration: none;
+            border: 1px solid transparent;
+          }
+          .selected {
+            border: 1px solid ${border};
+            border-radius: 8px;
+            background: ${bg};
+        }
+        .settings-body {
+            width: 100%;
+            min-width: 300px;
+            height: 100%;
+            overflow: auto;
+            margin-left: 32px;
+            margin-right: 32px;
+        }
+        "#,
+        bg = theme.background.clone(),
+        border = theme.border.clone(),
+    }
+    .expect("Failed to parse style");
     
     //Settings will display the nav bar, then depending on the route, will display the appropriate page (Account settings, ticket settings, etc)
     html!{
         //Match SettingsRoute to display the appropriate page
-        <div class="settings">
-            <SettingsNav />
-            <div class="settings-body">
-                // { if let AppRoute::SettingsRoot = route {
-                //     html!{
-                //         <div class="settings-body-header">
-                //             <h1>{ "Settings Root" }</h1>
-                //         </div>
-                //     }
-                { if let SettingsRoute::Profile = route {
-                    html!{
-                        <div class="settings-body-header">
-                            <h1>{ "Profile" }</h1>
-                        </div>
-                    }
-                } else if let SettingsRoute::Tickets = route {
-                    html!{
-                        <div class="settings-body-header">
-                            <h1>{ "Tickets" }</h1>
-                        </div>
-                    }
-                } else if let SettingsRoute::Account { user_id } = route {
-                    html!{
-                        <div class="settings-body-header">
-                            <AccountSettings user_id={Some(user_id.clone())}/>
-                        </div>
-                    }
-                } else {
-                    html!{}
-                }}
+        <div class={style}>
+            <div class="settings">
+                <SettingsNav />
+                <div class="settings-body">
+                    // { if let AppRoute::SettingsRoot = route {
+                    //     html!{
+                    //         <div class="settings-body-header">
+                    //             <h1>{ "Settings Root" }</h1>
+                    //         </div>
+                    //     }
+                    { if let SettingsRoute::Profile = route {
+                        html!{
+                            <div class="settings-body-header">
+                                <h1>{ "Profile" }</h1>
+                            </div>
+                        }
+                    } else if let SettingsRoute::Tickets = route {
+                        html!{
+                            <div class="settings-body-header">
+                                <h1>{ "Tickets" }</h1>
+                            </div>
+                        }
+                    } else if let SettingsRoute::Account { user_id } = route {
+                        html!{
+                            <div class="settings-body-header">
+                                <AccountSettings user_id={Some(user_id.clone())}/>
+                            </div>
+                        }
+                    } else {
+                        html!{}
+                    }}
+                </div>
             </div>
         </div>
     }

--- a/frontend/src/routes/settings/mod.rs
+++ b/frontend/src/routes/settings/mod.rs
@@ -1,26 +1,16 @@
-use web_sys::HtmlInputElement;
+mod account;
 
 use yew::prelude::*;
-use yew_router::Router;
-use yew_router::prelude::{use_navigator, use_route, Link};
+use yew_router::prelude::{use_route, Link};
 
-use crate::components::logout::Logout;
-use crate::components::select_locale::SelectLanguage;
 use crate::hooks::{use_language_context, use_user_context};
 use crate::routes::SettingsRoute;
-use crate::services::users::*;
-use crate::types::UserUpdateInfo;
 
 use super::AppRoute;
 
-#[derive(Clone, PartialEq, Properties)]
-pub struct Props {
-    pub user_id: Option<uuid::Uuid>,
-}
-
 /// Update user settings
 #[function_component(Settings)]
-pub fn settings(props: &Props) -> Html {
+pub fn settings() -> Html {
     let user_ctx = use_user_context();
     let language = use_language_context();
 
@@ -79,7 +69,7 @@ pub fn settings(props: &Props) -> Html {
                 } else if let SettingsRoute::Account { user_id } = route {
                     html!{
                         <div class="settings-body-header">
-                            <h1>{ "Account" }</h1>
+                            <account::AccountSettings user_id={Some(user_id.clone())}/>
                         </div>
                     }
                 } else {

--- a/frontend/src/routes/settings/mod.rs
+++ b/frontend/src/routes/settings/mod.rs
@@ -1,0 +1,92 @@
+use web_sys::HtmlInputElement;
+
+use yew::prelude::*;
+use yew_router::Router;
+use yew_router::prelude::{use_navigator, use_route, Link};
+
+use crate::components::logout::Logout;
+use crate::components::select_locale::SelectLanguage;
+use crate::hooks::{use_language_context, use_user_context};
+use crate::routes::SettingsRoute;
+use crate::services::users::*;
+use crate::types::UserUpdateInfo;
+
+use super::AppRoute;
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct Props {
+    pub user_id: Option<uuid::Uuid>,
+}
+
+/// Update user settings
+#[function_component(Settings)]
+pub fn settings(props: &Props) -> Html {
+    let user_ctx = use_user_context();
+    let language = use_language_context();
+
+    let route = match use_route::<SettingsRoute>() {
+        Some(route) => route,
+        None => SettingsRoute::Profile,
+    };
+    
+    //Settings will display the nav bar, then depending on the route, will display the appropriate page (Account settings, ticket settings, etc)
+    html!{
+        //Match SettingsRoute to display the appropriate page
+        <div class="settings">
+            <div class="settings-nav">
+                <div class="settings-nav-header">
+                    <h1>{ "Settings" }</h1>
+                </div>
+                <div class="settings-nav-body">
+                    <ul>
+                        <li>
+                            <Link<SettingsRoute> to={SettingsRoute::Profile} classes="nav-link">
+                                { "Profile" }
+                            </Link<SettingsRoute>>
+                        </li>
+                        <li>
+                            <Link<SettingsRoute> to={SettingsRoute::Tickets} classes="nav-link">
+                                { "Tickets" }
+                            </Link<SettingsRoute>>
+                        </li>
+                        <li>
+                            <Link<SettingsRoute> to={SettingsRoute::Account { user_id: user_ctx.user_id.clone() }} classes="nav-link">
+                                { "Account" }
+                            </Link<SettingsRoute>>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="settings-body">
+                // { if let AppRoute::SettingsRoot = route {
+                //     html!{
+                //         <div class="settings-body-header">
+                //             <h1>{ "Settings Root" }</h1>
+                //         </div>
+                //     }
+                { if let SettingsRoute::Profile = route {
+                    html!{
+                        <div class="settings-body-header">
+                            <h1>{ "Profile" }</h1>
+                        </div>
+                    }
+                } else if let SettingsRoute::Tickets = route {
+                    html!{
+                        <div class="settings-body-header">
+                            <h1>{ "Tickets" }</h1>
+                        </div>
+                    }
+                } else if let SettingsRoute::Account { user_id } = route {
+                    html!{
+                        <div class="settings-body-header">
+                            <h1>{ "Account" }</h1>
+                        </div>
+                    }
+                } else {
+                    html!{}
+                }}
+            </div>
+        </div>
+    }
+
+}

--- a/frontend/src/routes/settings/mod.rs
+++ b/frontend/src/routes/settings/mod.rs
@@ -1,18 +1,18 @@
 mod account;
+mod nav;
 
 use yew::prelude::*;
-use yew_router::prelude::{use_route, Link};
+use yew_router::prelude::use_route;
 
-use crate::hooks::{use_language_context, use_user_context};
 use crate::routes::SettingsRoute;
+use crate::routes::settings::account::AccountSettings;
+use crate::routes::settings::nav::SettingsNav;
 
 use super::AppRoute;
 
 /// Update user settings
 #[function_component(Settings)]
 pub fn settings() -> Html {
-    let user_ctx = use_user_context();
-    let language = use_language_context();
 
     let route = match use_route::<SettingsRoute>() {
         Some(route) => route,
@@ -23,30 +23,7 @@ pub fn settings() -> Html {
     html!{
         //Match SettingsRoute to display the appropriate page
         <div class="settings">
-            <div class="settings-nav">
-                <div class="settings-nav-header">
-                    <h1>{ "Settings" }</h1>
-                </div>
-                <div class="settings-nav-body">
-                    <ul>
-                        <li>
-                            <Link<SettingsRoute> to={SettingsRoute::Profile} classes="nav-link">
-                                { "Profile" }
-                            </Link<SettingsRoute>>
-                        </li>
-                        <li>
-                            <Link<SettingsRoute> to={SettingsRoute::Tickets} classes="nav-link">
-                                { "Tickets" }
-                            </Link<SettingsRoute>>
-                        </li>
-                        <li>
-                            <Link<SettingsRoute> to={SettingsRoute::Account { user_id: user_ctx.user_id.clone() }} classes="nav-link">
-                                { "Account" }
-                            </Link<SettingsRoute>>
-                        </li>
-                    </ul>
-                </div>
-            </div>
+            <SettingsNav />
             <div class="settings-body">
                 // { if let AppRoute::SettingsRoot = route {
                 //     html!{
@@ -69,7 +46,7 @@ pub fn settings() -> Html {
                 } else if let SettingsRoute::Account { user_id } = route {
                     html!{
                         <div class="settings-body-header">
-                            <account::AccountSettings user_id={Some(user_id.clone())}/>
+                            <AccountSettings user_id={Some(user_id.clone())}/>
                         </div>
                     }
                 } else {

--- a/frontend/src/routes/settings/nav.rs
+++ b/frontend/src/routes/settings/nav.rs
@@ -11,30 +11,28 @@ pub fn settings_nav() -> Html {
     let language = use_language_context();
 
     html!{
-        <div class="settings">
-            <div class="settings-nav">
-                <div class="settings-nav-header">
-                    <h1>{ "Settings" }</h1>
-                </div>
-                <div class="settings-nav-body">
-                    <ul>
-                        <li>
-                            <Link<SettingsRoute> to={SettingsRoute::Profile} classes="nav-link">
-                                { language.get("Profile") }
-                            </Link<SettingsRoute>>
-                        </li>
-                        <li>
-                            <Link<SettingsRoute> to={SettingsRoute::Tickets} classes="nav-link">
-                                { "Tickets" }
-                            </Link<SettingsRoute>>
-                        </li>
-                        <li>
-                            <Link<SettingsRoute> to={SettingsRoute::Account { user_id: user_ctx.user_id.clone() }} classes="nav-link">
-                                { "Account" }
-                            </Link<SettingsRoute>>
-                        </li>
-                    </ul>
-                </div>
+        <div class="settings-nav">
+            <div class="settings-nav-header">
+                <h1>{ "Settings" }</h1>
+            </div>
+            <div class="settings-nav-body">
+                <ul>
+                    <li>
+                        <Link<SettingsRoute> to={SettingsRoute::Profile} classes="nav-link">
+                            { language.get("Profile") }
+                        </Link<SettingsRoute>>
+                    </li>
+                    <li>
+                        <Link<SettingsRoute> to={SettingsRoute::Tickets} classes="nav-link">
+                            { "Tickets" }
+                        </Link<SettingsRoute>>
+                    </li>
+                    <li>
+                        <Link<SettingsRoute> to={SettingsRoute::Account { user_id: user_ctx.user_id.clone() }} classes="nav-link">
+                            { "Account" }
+                        </Link<SettingsRoute>>
+                    </li>
+                </ul>
             </div>
         </div>
     }

--- a/frontend/src/routes/settings/nav.rs
+++ b/frontend/src/routes/settings/nav.rs
@@ -1,0 +1,44 @@
+use yew::prelude::*;
+use yew_router::prelude::Link;
+
+use crate::hooks::{use_language_context, use_user_context};
+use crate::routes::SettingsRoute;
+
+/// Update user settings
+#[function_component(SettingsNav)]
+pub fn settings_nav() -> Html {
+    let user_ctx = use_user_context();
+    let language = use_language_context();
+
+    
+    //Settings will display the nav bar, then depending on the route, will display the appropriate page (Account settings, ticket settings, etc)
+    html!{
+        //Match SettingsRoute to display the appropriate page
+        <div class="settings">
+            <div class="settings-nav">
+                <div class="settings-nav-header">
+                    <h1>{ "Settings" }</h1>
+                </div>
+                <div class="settings-nav-body">
+                    <ul>
+                        <li>
+                            <Link<SettingsRoute> to={SettingsRoute::Profile} classes="nav-link">
+                                { language.get("Profile") }
+                            </Link<SettingsRoute>>
+                        </li>
+                        <li>
+                            <Link<SettingsRoute> to={SettingsRoute::Tickets} classes="nav-link">
+                                { "Tickets" }
+                            </Link<SettingsRoute>>
+                        </li>
+                        <li>
+                            <Link<SettingsRoute> to={SettingsRoute::Account { user_id: user_ctx.user_id.clone() }} classes="nav-link">
+                                { "Account" }
+                            </Link<SettingsRoute>>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    }
+}

--- a/frontend/src/routes/settings/nav.rs
+++ b/frontend/src/routes/settings/nav.rs
@@ -10,10 +10,7 @@ pub fn settings_nav() -> Html {
     let user_ctx = use_user_context();
     let language = use_language_context();
 
-    
-    //Settings will display the nav bar, then depending on the route, will display the appropriate page (Account settings, ticket settings, etc)
     html!{
-        //Match SettingsRoute to display the appropriate page
         <div class="settings">
             <div class="settings-nav">
                 <div class="settings-nav-header">

--- a/frontend/src/routes/users.rs
+++ b/frontend/src/routes/users.rs
@@ -1,7 +1,7 @@
 use yew::{prelude::*, suspense::use_future};
 use yew_router::prelude::{Link, Redirect};
 
-use crate::{hooks::use_user_context, services::users::get_users};
+use crate::{hooks::use_user_context, services::users::get_users, routes::SettingsRoute};
 
 use super::AppRoute;
 
@@ -33,9 +33,9 @@ pub fn users() -> Html {
                             for user_list.iter().map(|user| {
                                 html! {
                                     <tr>
-                                    <Link<AppRoute> to={AppRoute::SettingsOther { user_id: user.user_id.clone() }} classes="nav-link">
+                                    <Link<SettingsRoute> to={SettingsRoute::Account { user_id: user.user_id.clone() }} classes="nav-link">
                                         <td>{ &user.username }</td>
-                                    </Link<AppRoute>>
+                                    </Link<SettingsRoute>>
                                     </tr>
                                 }
                             })


### PR DESCRIPTION
The setting routing needs to be redone to allow for subpages.  This PR attempts to use yew_router's nested routing feature, as opposed to creating various Settings routes underneath AppRoute.  Nested routers would make routing a bit cleaner as the app grows but may introduce complications, especially due to changing APIs in yew, so I'm not sure if I'll move forward with it.